### PR TITLE
set initial joint position and velocity from the hardware interface

### DIFF
--- a/zx200_control/src/upper_arm_velocity_hardware.cpp
+++ b/zx200_control/src/upper_arm_velocity_hardware.cpp
@@ -44,6 +44,46 @@ hardware_interface::CallbackReturn Zx200UpperArmVelocityHardware::on_init(const 
 
   position_states_.resize(info_.joints.size(), 0);
   velocity_states_.resize(info_.joints.size(), 0);
+
+  // get initial joint position and velocity from the hardware interface
+  for (uint i = 0; i < info_.joints.size(); i++)
+  {
+    std::string joint_name = info_.joints[i].name;
+
+    auto get_initial_value =
+    [this, joint_name](const hardware_interface::InterfaceInfo & interface_info) {
+      double initial_value{0.0};
+      if (!interface_info.initial_value.empty()) {
+        try {
+          initial_value = std::stod(interface_info.initial_value);
+          RCLCPP_INFO(node_->get_logger(), "\t\t\t found initial value: %f", initial_value);
+        } catch (std::invalid_argument &) {
+          RCLCPP_ERROR_STREAM(
+            node_->get_logger(),
+            "Failed converting initial_value string to real number for the joint "
+              << joint_name
+              << " and state interface " << interface_info.name
+              << ". Actual value of parameter: " << interface_info.initial_value
+              << ". Initial value will be set to 0.0");
+          throw std::invalid_argument("Failed converting initial_value string");
+        }
+      }
+      return initial_value;
+    };
+  
+    for (const hardware_interface::InterfaceInfo & interface_info : info_.joints[i].state_interfaces)
+    {
+      if (interface_info.name == hardware_interface::HW_IF_POSITION)
+      {
+        position_states_[i] = latest_joint_states_.position[i] = get_initial_value(interface_info);
+      }
+      else if (interface_info.name == hardware_interface::HW_IF_VELOCITY)
+      {
+        velocity_states_[i] = latest_joint_states_.velocity[i] = get_initial_value(interface_info);
+      }
+    }
+  }
+
   // old_position_states_.resize(info_.joints.size(), 0);
   // predicted_positions_.resize(info_.joints.size(), 0);
 
@@ -151,12 +191,11 @@ Zx200UpperArmVelocityHardware::on_deactivate(const rclcpp_lifecycle::State& /*pr
 hardware_interface::return_type Zx200UpperArmVelocityHardware::read(const rclcpp::Time& /*time*/,
                                                                     const rclcpp::Duration& /*period*/)
 {
-  for (int i = 0; i < latest_joint_states_.name.size(); i++)
+  for (uint i = 0; i < latest_joint_states_.name.size(); i++)
   {
     position_states_[i] = latest_joint_states_.position[i];
     velocity_states_[i] = latest_joint_states_.velocity[i];
   }
-
   return hardware_interface::return_type::OK;
 }
 


### PR DESCRIPTION
@maopotcha @genkiiii 
シミュレータ＋moveit2でアームが可動角を超えて伸び切った状態で始まってしまい、逆運動学計算エラーで落ちる問題があったの件の修正です（詳しくは下のコメントを参照ください）。
https://github.com/pwri-opera/OperaSim-PhysX/issues/89#issuecomment-2795600961

実機での動作は確認できていないので、その点、大丈夫そうでしたらマージください。