### PR TITLE
Update: ROS2通信・ノード名に"zx200"という接頭辞をつけられるようにしました

### DIFF
--- a/zx200_bringup/launch/vehicle.launch.py
+++ b/zx200_bringup/launch/vehicle.launch.py
@@ -1,14 +1,16 @@
+#!/usr/bin/env python3
 from launch import LaunchDescription, LaunchContext
 from launch.actions import (
     DeclareLaunchArgument,
     IncludeLaunchDescription,
-    OpaqueFunction
+    OpaqueFunction,
+    GroupAction,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, PushRosNamespace
 from launch_ros.parameter_descriptions import ParameterValue
 
 from srdfdom.srdf import SRDF
@@ -17,6 +19,7 @@ from moveit_configs_utils.launch_utils import (
     add_debuggable_node,
     DeclareBooleanLaunchArg,
 )
+from moveit_configs_utils.launch_utils import DeclareBooleanLaunchArg
 from moveit_configs_utils import MoveItConfigsBuilder
 from moveit_configs_utils.launches import generate_demo_launch
 
@@ -30,6 +33,8 @@ def generate_launch_description():
 
     ld = LaunchDescription()
 
+    ld.add_action(DeclareLaunchArgument("robot_name", default_value="zx200"))
+    ld.add_action(DeclareLaunchArgument("command_interface_name", default_value="effort"))
     ld.add_action(declare_robot_name)
     ld.add_action(declare_command_interface_name)
     ld.add_action(OpaqueFunction(function=launch_setup))
@@ -40,19 +45,30 @@ def generate_launch_description():
 def launch_setup(context, *args, **kwargs):
 
     robot_name_str = LaunchConfiguration("robot_name").perform(context)
-    command_interface_name_str = LaunchConfiguration(
-        "command_interface_name").perform(context)
+    command_interface_name_str = LaunchConfiguration("command_interface_name").perform(context)
 
     # Generate the MoveIt configuration
     moveit_config = (
         MoveItConfigsBuilder(
-            robot_name=robot_name_str, package_name=robot_name_str+"_moveit_config")
-        .robot_description(file_path="config/"+robot_name_str+"_"+command_interface_name_str+".urdf.xacro")
+            robot_name=robot_name_str,
+            package_name=f"{robot_name_str}_moveit_config"
+        )
+        .robot_description(
+            file_path=f"config/{robot_name_str}_{command_interface_name_str}.urdf.xacro"
+        )
         .to_moveit_configs()
     )
 
-    return [generate_demo_launch_switch_command_interface(moveit_config, command_interface_name_str)]
-
+    return [
+        GroupAction(
+            actions=[
+                PushRosNamespace(robot_name_str),
+                *generate_demo_launch_switch_command_interface(
+                    moveit_config, command_interface_name_str
+                )
+            ]
+        )
+    ]
 
 def generate_demo_launch_switch_command_interface(moveit_config, command_interface):
     """
@@ -66,92 +82,78 @@ def generate_demo_launch_switch_command_interface(moveit_config, command_interfa
      * warehouse_db (optional)
      * ros2_control_node + controller spawners
     """
-    ld = LaunchDescription()
-    ld.add_action(
-        DeclareBooleanLaunchArg(
-            "db",
-            default_value=False,
-            description="By default, we do not start a database (it can be large)",
-        )
-    )
-    ld.add_action(
-        DeclareBooleanLaunchArg(
-            "debug",
-            default_value=False,
-            description="By default, we are not in debug mode",
-        )
-    )
-    ld.add_action(DeclareBooleanLaunchArg("use_rviz", default_value=False))
+    actions = []
 
-    # If there are virtual joints, broadcast static tf by including virtual_joints launch
-    virtual_joints_launch = (
-        moveit_config.package_path / "launch/static_virtual_joint_tfs.launch.py"
-    )
-    if virtual_joints_launch.exists():
-        ld.add_action(
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(str(virtual_joints_launch)),
-            )
+    # Boolean Launch Args
+    actions.append(DeclareBooleanLaunchArg("db", default_value=False,
+                                           description="Start MongoDB if true"))
+    actions.append(DeclareBooleanLaunchArg("debug", default_value=False,
+                                           description="Enable debug mode"))
+    actions.append(DeclareBooleanLaunchArg("use_rviz", default_value=False,
+                                           description="Launch RViz if true"))
+
+    # If there are virtual joints, broadcast static tf by including virtual_joints launch# If there are virtual joints, broadcast static tf by including virtual_joints launch
+    svj = moveit_config.package_path / "launch" / "static_virtual_joint_tfs.launch.py"
+    if svj.exists():
+        actions.append(
+            IncludeLaunchDescription(PythonLaunchDescriptionSource(str(svj)))
         )
 
     # Given the published joint states, publish tf for the robot links
-    ld.add_action(
+    actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/rsp.launch.py")
-            ),
+                str(moveit_config.package_path / "launch" / "rsp.launch.py")
+            )
         )
     )
-
-    ld.add_action(
+    actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/move_group.launch.py")
-            ),
+                str(moveit_config.package_path / "launch" / "move_group.launch.py")
+            )
         )
     )
 
     # Run Rviz and load the default config to see the state of the move_group node
-    ld.add_action(
+    actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/moveit_rviz.launch.py")
+                str(moveit_config.package_path / "launch" / "moveit_rviz.launch.py")
             ),
             condition=IfCondition(LaunchConfiguration("use_rviz")),
         )
     )
 
     # If database loading was enabled, start mongodb as well
-    ld.add_action(
+    actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path / "launch/warehouse_db.launch.py")
+                str(moveit_config.package_path / "launch" / "warehouse_db.launch.py")
             ),
             condition=IfCondition(LaunchConfiguration("db")),
         )
     )
 
     # Start the ros2_control node
-    ros2_controllers_file_name = "ros2_" + command_interface + "_controllers.yaml"
-    ld.add_action(
+    yaml_file = str(
+        moveit_config.package_path / "config" /
+        f"ros2_{command_interface}_controllers.yaml"
+    )
+    actions.append(
         Node(
             package="controller_manager",
             executable="ros2_control_node",
-            parameters=[
-                moveit_config.robot_description,
-                str(moveit_config.package_path /
-                    "config" / ros2_controllers_file_name),
-            ],
+            parameters=[moveit_config.robot_description, yaml_file],
         )
     )
 
-    ld.add_action(
+    actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                str(moveit_config.package_path /
-                    "launch/spawn_controllers.launch.py")
-            ),
+                str(moveit_config.package_path / "launch" / "spawn_controllers.launch.py")
+            )
         )
     )
 
-    return ld
+    return actions


### PR DESCRIPTION
表題のとおりです。以下の通りlaunch.pyファイルを起動するとROS2ノード・トピックに"zx200"という接頭辞が付与されるようにしました。

ros2 launch zx200_bringup vehicle.launch.py command_interface_name:=velocity

一方で"zx200"以外の接頭辞を指定できない状態となっています。改修しようと試みたのですが、時間がかかりそうな予感がしたため、断念しました。OperaSim-PhysXを使用して動作確認を行い、正常に接頭辞が付与された上で建機を意図したとおり動作可能なことを確認しました。一方で、実機では動作確認していない点にご留意ください。



