### PR TITLE
Add angle_wraparound=true to swing joint in ros2_velocity_controllers…

### DIFF
--- a/zx200_moveit_config/config/ros2_velocity_controllers.yaml
+++ b/zx200_moveit_config/config/ros2_velocity_controllers.yaml
@@ -33,7 +33,7 @@
         # boom_joint: {p: 1.4, i: 0.0, d: 0.0}
         # arm_joint: {p: 1.5, i: 0.0, d: 0.0}
         # bucket_joint: {p: 1.0, i: 0.0, d: 0.0}
-        swing_joint: {p: 1.2,  i: 0.3, d: 0.0}
+        swing_joint: {p: 1.2,  i: 0.3, d: 0.0, angle_wraparound: true}
         boom_joint: {p: 2.4, i: 0.3, d: 0.2}
         arm_joint: {p: 2.5, i: 0.3, d: 0.2}
         bucket_joint: {p: 2.0, i: 0.3, d: 0.2}


### PR DESCRIPTION
swing軸がvelocity_contorl時に＋πまたはーπ付近で、意図した方向と逆向きに動いてしまう不具合への対応